### PR TITLE
Track cart origin and parent-child relationships for admin orders

### DIFF
--- a/Observer/SetQuoteSourceObserver.php
+++ b/Observer/SetQuoteSourceObserver.php
@@ -10,17 +10,8 @@ use Magento\Framework\Event\ObserverInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Sets tnw_quote_source on any quote that reaches submission (cart → order
- * conversion) without a source label. Acts as a fallback when the admin plugin
- * hasn't already stamped the value:
- *   - quote.orig_order_id  → 'reorder'
- *   - area webapi_rest/soap → 'api'
- *   - area adminhtml        → 'admin_manual' (shouldn't normally reach here
- *                             because RecordSourceCartPlugin runs first)
- *   - frontend              → 'customer_frontend'
- *
- * IdealData reads tnw_quote_source to distinguish between customer-initiated
- * and admin-initiated carts/orders.
+ * Sets tnw_quote_source on quotes at submission time for non-admin contexts.
+ * Admin-created orders are handled by RecordSourceCartPlugin (aroundCreateOrder).
  */
 class SetQuoteSourceObserver implements ObserverInterface
 {
@@ -38,11 +29,6 @@ class SetQuoteSourceObserver implements ObserverInterface
                 return;
             }
 
-            if ($quote->getOrigOrderId()) {
-                $quote->setData('tnw_quote_source', 'reorder');
-                return;
-            }
-
             $areaCode = null;
             try {
                 $areaCode = $this->appState->getAreaCode();
@@ -50,10 +36,15 @@ class SetQuoteSourceObserver implements ObserverInterface
                 // area not initialized
             }
 
-            if (in_array($areaCode, ['webapi_rest', 'webapi_soap'], true)) {
+            // Admin orders are handled by RecordSourceCartPlugin — skip here
+            if ($areaCode === 'adminhtml') {
+                return;
+            }
+
+            if ($quote->getOrigOrderId()) {
+                $quote->setData('tnw_quote_source', 'reorder');
+            } elseif (in_array($areaCode, ['webapi_rest', 'webapi_soap'], true)) {
                 $quote->setData('tnw_quote_source', 'api');
-            } elseif ($areaCode === 'adminhtml') {
-                $quote->setData('tnw_quote_source', 'admin_manual');
             } else {
                 $quote->setData('tnw_quote_source', 'customer_frontend');
             }

--- a/Observer/SetQuoteSourceObserver.php
+++ b/Observer/SetQuoteSourceObserver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TNW\Idealdata\Observer;
+
+use Magento\Framework\App\State;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Sets tnw_quote_source on any quote that reaches submission (cart → order
+ * conversion) without a source label. Acts as a fallback when the admin plugin
+ * hasn't already stamped the value:
+ *   - quote.orig_order_id  → 'reorder'
+ *   - area webapi_rest/soap → 'api'
+ *   - area adminhtml        → 'admin_manual' (shouldn't normally reach here
+ *                             because RecordSourceCartPlugin runs first)
+ *   - frontend              → 'customer_frontend'
+ *
+ * IdealData reads tnw_quote_source to distinguish between customer-initiated
+ * and admin-initiated carts/orders.
+ */
+class SetQuoteSourceObserver implements ObserverInterface
+{
+    public function __construct(
+        private readonly State $appState,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    public function execute(Observer $observer): void
+    {
+        try {
+            $quote = $observer->getEvent()->getQuote();
+            if (!$quote || $quote->getData('tnw_quote_source')) {
+                return;
+            }
+
+            if ($quote->getOrigOrderId()) {
+                $quote->setData('tnw_quote_source', 'reorder');
+                return;
+            }
+
+            $areaCode = null;
+            try {
+                $areaCode = $this->appState->getAreaCode();
+            } catch (\Throwable $e) {
+                // area not initialized
+            }
+
+            if (in_array($areaCode, ['webapi_rest', 'webapi_soap'], true)) {
+                $quote->setData('tnw_quote_source', 'api');
+            } elseif ($areaCode === 'adminhtml') {
+                $quote->setData('tnw_quote_source', 'admin_manual');
+            } else {
+                $quote->setData('tnw_quote_source', 'customer_frontend');
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'TNW_Idealdata: Failed to set tnw_quote_source',
+                ['exception' => $e->getMessage()]
+            );
+        }
+    }
+}

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -9,21 +9,30 @@ use Magento\Sales\Model\AdminOrder\Create;
 use Psr\Log\LoggerInterface;
 
 /**
- * When admin creates an order with "Move items from customer's cart", Magento
- * creates a NEW quote (Cart B), moves items from the customer's persistent cart
- * (Cart A), and converts Cart B to the order. This plugin stamps Cart B with:
+ * Records the origin of a quote created during admin order creation.
  *
- *  - tnw_quote_source = 'admin_split_from_cart' | 'admin_manual'
- *  - tnw_parent_quote_id = Cart A id (when applicable)
- *  - tnw_parent_quote_created_at = Cart A created_at (when applicable)
+ * Three scenarios:
  *
- * It also stamps Cart A with tnw_child_quote_id pointing at Cart B, so
- * IdealData can efficiently detect "drained" Cart A's in the lifecycle
- * processor and remove them.
+ * 1. "Move items from customer's cart" — admin explicitly transfers items
+ *    from the customer's persistent cart (Cart A) into a new quote (Cart B).
+ *    Detected via $subject->getMoveQuoteItems(). Cart B gets:
+ *      tnw_quote_source       = 'admin_split_from_cart'
+ *      tnw_parent_quote_id    = Cart A entity_id
+ *      tnw_parent_quote_created_at = Cart A created_at
+ *    Cart A gets tnw_child_quote_id = Cart B entity_id (via raw SQL).
  *
- * IMPORTANT: Cart A is updated via raw SQL (not $quote->save()) to avoid
- * triggering collectTotals / observers / plugins that can interfere with
- * the Cart B → Order conversion happening right after this plugin.
+ * 2. Reorder — admin creates order from an existing order's data.
+ *    Detected via $orderQuote->getOrigOrderId(). Cart B gets:
+ *      tnw_quote_source = 'reorder'
+ *    Cart A is NOT touched.
+ *
+ * 3. Manual order — admin creates order from scratch for a customer.
+ *    Cart B gets:
+ *      tnw_quote_source = 'admin_manual'
+ *    Cart A is NOT touched.
+ *
+ * Cart A is updated via raw SQL (not $quote->save()) to avoid triggering
+ * collectTotals / observers that interfere with the Cart B → Order conversion.
  */
 class RecordSourceCartPlugin
 {
@@ -34,8 +43,6 @@ class RecordSourceCartPlugin
     }
 
     /**
-     * Runs right before Magento converts the admin-built quote into an order.
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeCreateOrder(Create $subject): void
@@ -46,30 +53,38 @@ class RecordSourceCartPlugin
                 return;
             }
 
-            $customerCart = $subject->getCustomerCart();
-            if ($customerCart
-                && $customerCart->getId()
-                && (int) $customerCart->getId() !== (int) $orderQuote->getId()
-            ) {
-                // Stamp Cart B with parent info (saved by Magento during createOrder)
-                $orderQuote->setData('tnw_quote_source', 'admin_split_from_cart');
-                $orderQuote->setData('tnw_parent_quote_id', (int) $customerCart->getId());
-                if ($customerCart->getCreatedAt()) {
-                    $orderQuote->setData('tnw_parent_quote_created_at', $customerCart->getCreatedAt());
-                }
+            // Scenario 1: items explicitly moved from customer's cart
+            if ($subject->getMoveQuoteItems()) {
+                $customerCart = $subject->getCustomerCart();
+                if ($customerCart
+                    && $customerCart->getId()
+                    && (int) $customerCart->getId() !== (int) $orderQuote->getId()
+                ) {
+                    $orderQuote->setData('tnw_quote_source', 'admin_split_from_cart');
+                    $orderQuote->setData('tnw_parent_quote_id', (int) $customerCart->getId());
+                    if ($customerCart->getCreatedAt()) {
+                        $orderQuote->setData('tnw_parent_quote_created_at', $customerCart->getCreatedAt());
+                    }
 
-                // Stamp Cart A with child info via raw SQL — avoids triggering
-                // Quote::save() which would call collectTotals/observers and can
-                // break the ongoing Cart B → Order conversion.
-                $connection = $this->resourceConnection->getConnection();
-                $connection->update(
-                    $this->resourceConnection->getTableName('quote'),
-                    ['tnw_child_quote_id' => (int) $orderQuote->getId()],
-                    ['entity_id = ?' => (int) $customerCart->getId()]
-                );
-            } else {
-                $orderQuote->setData('tnw_quote_source', 'admin_manual');
+                    // Stamp Cart A with child reference (raw SQL to avoid side effects)
+                    $connection = $this->resourceConnection->getConnection();
+                    $connection->update(
+                        $this->resourceConnection->getTableName('quote'),
+                        ['tnw_child_quote_id' => (int) $orderQuote->getId()],
+                        ['entity_id = ?' => (int) $customerCart->getId()]
+                    );
+                    return;
+                }
             }
+
+            // Scenario 2: reorder
+            if ($orderQuote->getOrigOrderId()) {
+                $orderQuote->setData('tnw_quote_source', 'reorder');
+                return;
+            }
+
+            // Scenario 3: manual admin order
+            $orderQuote->setData('tnw_quote_source', 'admin_manual');
         } catch (\Throwable $e) {
             $this->logger->warning(
                 'TNW_Idealdata: Failed to record admin cart source',

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -85,10 +85,10 @@ class RecordSourceCartPlugin
                 return $result;
             }
 
-            // All raw SQL updates on Cart B include updated_at bump to ensure
-            // the IdealData connector re-fetches the cart with tnw_* values
-            // on the next sync cycle (sync filters by updated_at >= lastSyncTime).
-            $now = date('Y-m-d H:i:s');
+            // All raw SQL updates include updated_at bump to force a re-sync.
+            // Use current time +1s to guarantee the value is AFTER whatever
+            // createOrder() wrote (which just completed inside $proceed).
+            $now = date('Y-m-d H:i:s', time() + 1);
 
             // Scenario 1: reorder
             if ($orderQuote->getOrigOrderId()) {

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -85,13 +85,17 @@ class RecordSourceCartPlugin
                 return $result;
             }
 
+            // All raw SQL updates on Cart B include updated_at bump to ensure
+            // the IdealData connector re-fetches the cart with tnw_* values
+            // on the next sync cycle (sync filters by updated_at >= lastSyncTime).
+            $now = date('Y-m-d H:i:s');
+
             // Scenario 1: reorder
             if ($orderQuote->getOrigOrderId()) {
-                $connection->update(
-                    $tableName,
-                    ['tnw_quote_source' => 'reorder'],
-                    ['entity_id = ?' => $quoteId]
-                );
+                $connection->update($tableName, [
+                    'tnw_quote_source' => 'reorder',
+                    'updated_at' => $now
+                ], ['entity_id = ?' => $quoteId]);
                 return $result;
             }
 
@@ -107,11 +111,13 @@ class RecordSourceCartPlugin
                     $connection->update($tableName, [
                         'tnw_quote_source' => 'admin_split_from_cart',
                         'tnw_parent_quote_id' => $cartAId,
-                        'tnw_parent_quote_created_at' => $cartACreatedAt
+                        'tnw_parent_quote_created_at' => $cartACreatedAt,
+                        'updated_at' => $now
                     ], ['entity_id = ?' => $quoteId]);
 
                     $connection->update($tableName, [
-                        'tnw_child_quote_id' => $quoteId
+                        'tnw_child_quote_id' => $quoteId,
+                        'updated_at' => $now
                     ], ['entity_id = ?' => $cartAId]);
 
                     return $result;
@@ -119,11 +125,10 @@ class RecordSourceCartPlugin
             }
 
             // Scenario 3: manual admin order (no items moved, no reorder)
-            $connection->update(
-                $tableName,
-                ['tnw_quote_source' => 'admin_manual'],
-                ['entity_id = ?' => $quoteId]
-            );
+            $connection->update($tableName, [
+                'tnw_quote_source' => 'admin_manual',
+                'updated_at' => $now
+            ], ['entity_id = ?' => $quoteId]);
         } catch (\Throwable $e) {
             $this->logger->warning(
                 'TNW_Idealdata: Failed to record admin cart source',

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TNW\Idealdata\Plugin\AdminOrder;
+
+use Magento\Sales\Model\AdminOrder\Create;
+use Psr\Log\LoggerInterface;
+
+/**
+ * When admin creates an order with "Move items from customer's cart", Magento
+ * creates a NEW quote (Cart B), moves items from the customer's persistent cart
+ * (Cart A), and converts Cart B to the order. This plugin stamps Cart B with:
+ *
+ *  - tnw_quote_source = 'admin_split_from_cart' | 'admin_manual'
+ *  - tnw_parent_quote_id = Cart A id (when applicable)
+ *  - tnw_parent_quote_created_at = Cart A created_at (when applicable)
+ *
+ * IdealData uses these fields to restore the Cart A → Cart B → Order lineage
+ * and to compute the correct cart status / time-to-convert.
+ */
+class RecordSourceCartPlugin
+{
+    public function __construct(
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Runs right before Magento converts the admin-built quote into an order.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeCreateOrder(Create $subject): void
+    {
+        try {
+            $orderQuote = $subject->getQuote();
+            if (!$orderQuote || $orderQuote->getData('tnw_quote_source')) {
+                return;
+            }
+
+            $customerCart = $subject->getCustomerCart();
+            if ($customerCart
+                && $customerCart->getId()
+                && (int) $customerCart->getId() !== (int) $orderQuote->getId()
+            ) {
+                $orderQuote->setData('tnw_quote_source', 'admin_split_from_cart');
+                $orderQuote->setData('tnw_parent_quote_id', (int) $customerCart->getId());
+                if ($customerCart->getCreatedAt()) {
+                    $orderQuote->setData('tnw_parent_quote_created_at', $customerCart->getCreatedAt());
+                }
+            } else {
+                $orderQuote->setData('tnw_quote_source', 'admin_manual');
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'TNW_Idealdata: Failed to record admin cart source',
+                ['exception' => $e->getMessage()]
+            );
+        }
+    }
+}

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -16,6 +16,10 @@ use Psr\Log\LoggerInterface;
  *  - tnw_parent_quote_id = Cart A id (when applicable)
  *  - tnw_parent_quote_created_at = Cart A created_at (when applicable)
  *
+ * It also stamps Cart A with tnw_child_quote_id pointing at Cart B, so
+ * IdealData can efficiently detect "drained" Cart A's in the lifecycle
+ * processor and remove them.
+ *
  * IdealData uses these fields to restore the Cart A → Cart B → Order lineage
  * and to compute the correct cart status / time-to-convert.
  */
@@ -44,11 +48,16 @@ class RecordSourceCartPlugin
                 && $customerCart->getId()
                 && (int) $customerCart->getId() !== (int) $orderQuote->getId()
             ) {
+                // Stamp Cart B with parent info
                 $orderQuote->setData('tnw_quote_source', 'admin_split_from_cart');
                 $orderQuote->setData('tnw_parent_quote_id', (int) $customerCart->getId());
                 if ($customerCart->getCreatedAt()) {
                     $orderQuote->setData('tnw_parent_quote_created_at', $customerCart->getCreatedAt());
                 }
+
+                // Stamp Cart A with child info (for lifecycle cleanup detection)
+                $customerCart->setData('tnw_child_quote_id', (int) $orderQuote->getId());
+                $customerCart->save();
             } else {
                 $orderQuote->setData('tnw_quote_source', 'admin_manual');
             }

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -9,30 +9,23 @@ use Magento\Sales\Model\AdminOrder\Create;
 use Psr\Log\LoggerInterface;
 
 /**
- * Records the origin of a quote created during admin order creation.
+ * Detects the origin of an admin-created order by comparing the customer's
+ * active cart (Cart A) items_count before and after createOrder().
  *
- * Three scenarios:
+ * Magento's admin order creation is multi-step: items are moved during
+ * _processActionData() in an earlier request, and by the time createOrder()
+ * runs, the _moveQuoteItems flag is lost. So we use a before/after snapshot
+ * of Cart A's items_count to detect whether items were transferred.
  *
- * 1. "Move items from customer's cart" — admin explicitly transfers items
- *    from the customer's persistent cart (Cart A) into a new quote (Cart B).
- *    Detected via $subject->getMoveQuoteItems(). Cart B gets:
- *      tnw_quote_source       = 'admin_split_from_cart'
- *      tnw_parent_quote_id    = Cart A entity_id
- *      tnw_parent_quote_created_at = Cart A created_at
- *    Cart A gets tnw_child_quote_id = Cart B entity_id (via raw SQL).
+ * Uses aroundCreateOrder to:
+ * 1. Snapshot Cart A items_count BEFORE
+ * 2. Run original createOrder()
+ * 3. Re-read Cart A items_count AFTER
+ * 4. If decreased → admin_split_from_cart + parent/child links
+ *    If origOrderId → reorder
+ *    Otherwise → admin_manual
  *
- * 2. Reorder — admin creates order from an existing order's data.
- *    Detected via $orderQuote->getOrigOrderId(). Cart B gets:
- *      tnw_quote_source = 'reorder'
- *    Cart A is NOT touched.
- *
- * 3. Manual order — admin creates order from scratch for a customer.
- *    Cart B gets:
- *      tnw_quote_source = 'admin_manual'
- *    Cart A is NOT touched.
- *
- * Cart A is updated via raw SQL (not $quote->save()) to avoid triggering
- * collectTotals / observers that interfere with the Cart B → Order conversion.
+ * All quote updates are via raw SQL to avoid side effects (collectTotals etc).
  */
 class RecordSourceCartPlugin
 {
@@ -45,51 +38,99 @@ class RecordSourceCartPlugin
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeCreateOrder(Create $subject): void
+    public function aroundCreateOrder(Create $subject, callable $proceed)
     {
+        // ── Snapshot Cart A state BEFORE createOrder ─────────────────────
+        $orderQuote = $subject->getQuote();
+        $customerCart = null;
+        $cartAId = null;
+        $cartAItemsBefore = 0;
+        $cartACreatedAt = null;
+
         try {
-            $orderQuote = $subject->getQuote();
-            if (!$orderQuote || $orderQuote->getData('tnw_quote_source')) {
-                return;
+            $customerCart = $subject->getCustomerCart();
+            if ($customerCart
+                && $customerCart->getId()
+                && $orderQuote
+                && (int) $customerCart->getId() !== (int) $orderQuote->getId()
+            ) {
+                $cartAId = (int) $customerCart->getId();
+                $cartAItemsBefore = (int) $customerCart->getItemsCount();
+                $cartACreatedAt = $customerCart->getCreatedAt();
+            }
+        } catch (\Throwable $e) {
+            // Can't read customer cart — proceed without tracking
+        }
+
+        // ── Run original createOrder ─────────────────────────────────────
+        $result = $proceed();
+
+        // ── Determine source and stamp via raw SQL ───────────────────────
+        try {
+            if (!$orderQuote || !$orderQuote->getId()) {
+                return $result;
             }
 
-            // Scenario 1: items explicitly moved from customer's cart
-            if ($subject->getMoveQuoteItems()) {
-                $customerCart = $subject->getCustomerCart();
-                if ($customerCart
-                    && $customerCart->getId()
-                    && (int) $customerCart->getId() !== (int) $orderQuote->getId()
-                ) {
-                    $orderQuote->setData('tnw_quote_source', 'admin_split_from_cart');
-                    $orderQuote->setData('tnw_parent_quote_id', (int) $customerCart->getId());
-                    if ($customerCart->getCreatedAt()) {
-                        $orderQuote->setData('tnw_parent_quote_created_at', $customerCart->getCreatedAt());
-                    }
+            $connection = $this->resourceConnection->getConnection();
+            $tableName = $this->resourceConnection->getTableName('quote');
+            $quoteId = (int) $orderQuote->getId();
 
-                    // Stamp Cart A with child reference (raw SQL to avoid side effects)
-                    $connection = $this->resourceConnection->getConnection();
-                    $connection->update(
-                        $this->resourceConnection->getTableName('quote'),
-                        ['tnw_child_quote_id' => (int) $orderQuote->getId()],
-                        ['entity_id = ?' => (int) $customerCart->getId()]
-                    );
-                    return;
+            // Check if already set (e.g. by SetQuoteSourceObserver — shouldn't
+            // happen since observer skips adminhtml, but be safe)
+            $existingSource = $connection->fetchOne(
+                "SELECT tnw_quote_source FROM {$tableName} WHERE entity_id = ?",
+                [$quoteId]
+            );
+            if ($existingSource) {
+                return $result;
+            }
+
+            // Scenario 1: reorder
+            if ($orderQuote->getOrigOrderId()) {
+                $connection->update(
+                    $tableName,
+                    ['tnw_quote_source' => 'reorder'],
+                    ['entity_id = ?' => $quoteId]
+                );
+                return $result;
+            }
+
+            // Scenario 2: items moved from customer cart
+            if ($cartAId && $cartAItemsBefore > 0) {
+                $cartAItemsAfter = (int) $connection->fetchOne(
+                    "SELECT items_count FROM {$tableName} WHERE entity_id = ?",
+                    [$cartAId]
+                );
+
+                if ($cartAItemsAfter < $cartAItemsBefore) {
+                    // Cart A lost items → they were moved to Cart B
+                    $connection->update($tableName, [
+                        'tnw_quote_source' => 'admin_split_from_cart',
+                        'tnw_parent_quote_id' => $cartAId,
+                        'tnw_parent_quote_created_at' => $cartACreatedAt
+                    ], ['entity_id = ?' => $quoteId]);
+
+                    $connection->update($tableName, [
+                        'tnw_child_quote_id' => $quoteId
+                    ], ['entity_id = ?' => $cartAId]);
+
+                    return $result;
                 }
             }
 
-            // Scenario 2: reorder
-            if ($orderQuote->getOrigOrderId()) {
-                $orderQuote->setData('tnw_quote_source', 'reorder');
-                return;
-            }
-
-            // Scenario 3: manual admin order
-            $orderQuote->setData('tnw_quote_source', 'admin_manual');
+            // Scenario 3: manual admin order (no items moved, no reorder)
+            $connection->update(
+                $tableName,
+                ['tnw_quote_source' => 'admin_manual'],
+                ['entity_id = ?' => $quoteId]
+            );
         } catch (\Throwable $e) {
             $this->logger->warning(
                 'TNW_Idealdata: Failed to record admin cart source',
                 ['exception' => $e->getMessage()]
             );
         }
+
+        return $result;
     }
 }

--- a/Plugin/AdminOrder/RecordSourceCartPlugin.php
+++ b/Plugin/AdminOrder/RecordSourceCartPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TNW\Idealdata\Plugin\AdminOrder;
 
+use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Model\AdminOrder\Create;
 use Psr\Log\LoggerInterface;
 
@@ -20,12 +21,14 @@ use Psr\Log\LoggerInterface;
  * IdealData can efficiently detect "drained" Cart A's in the lifecycle
  * processor and remove them.
  *
- * IdealData uses these fields to restore the Cart A → Cart B → Order lineage
- * and to compute the correct cart status / time-to-convert.
+ * IMPORTANT: Cart A is updated via raw SQL (not $quote->save()) to avoid
+ * triggering collectTotals / observers / plugins that can interfere with
+ * the Cart B → Order conversion happening right after this plugin.
  */
 class RecordSourceCartPlugin
 {
     public function __construct(
+        private readonly ResourceConnection $resourceConnection,
         private readonly LoggerInterface $logger
     ) {
     }
@@ -48,16 +51,22 @@ class RecordSourceCartPlugin
                 && $customerCart->getId()
                 && (int) $customerCart->getId() !== (int) $orderQuote->getId()
             ) {
-                // Stamp Cart B with parent info
+                // Stamp Cart B with parent info (saved by Magento during createOrder)
                 $orderQuote->setData('tnw_quote_source', 'admin_split_from_cart');
                 $orderQuote->setData('tnw_parent_quote_id', (int) $customerCart->getId());
                 if ($customerCart->getCreatedAt()) {
                     $orderQuote->setData('tnw_parent_quote_created_at', $customerCart->getCreatedAt());
                 }
 
-                // Stamp Cart A with child info (for lifecycle cleanup detection)
-                $customerCart->setData('tnw_child_quote_id', (int) $orderQuote->getId());
-                $customerCart->save();
+                // Stamp Cart A with child info via raw SQL — avoids triggering
+                // Quote::save() which would call collectTotals/observers and can
+                // break the ongoing Cart B → Order conversion.
+                $connection = $this->resourceConnection->getConnection();
+                $connection->update(
+                    $this->resourceConnection->getTableName('quote'),
+                    ['tnw_child_quote_id' => (int) $orderQuote->getId()],
+                    ['entity_id = ?' => (int) $customerCart->getId()]
+                );
             } else {
                 $orderQuote->setData('tnw_quote_source', 'admin_manual');
             }

--- a/Plugin/Cart/AddCartAttributesPlugin.php
+++ b/Plugin/Cart/AddCartAttributesPlugin.php
@@ -85,6 +85,24 @@ class AddCartAttributesPlugin
             $extensionAttributes->setCustomerIsGuest((int) $cart->getData('customer_is_guest'));
         }
 
+        // Cart parent tracking (populated for admin "move items from cart" flow)
+        if (method_exists($cart, 'getData')) {
+            $parentQuoteId = $cart->getData('tnw_parent_quote_id');
+            if ($parentQuoteId !== null && $parentQuoteId !== '') {
+                $extensionAttributes->setTnwParentQuoteId((int) $parentQuoteId);
+            }
+
+            $parentQuoteCreatedAt = $cart->getData('tnw_parent_quote_created_at');
+            if ($parentQuoteCreatedAt !== null && $parentQuoteCreatedAt !== '') {
+                $extensionAttributes->setTnwParentQuoteCreatedAt((string) $parentQuoteCreatedAt);
+            }
+
+            $quoteSource = $cart->getData('tnw_quote_source');
+            if ($quoteSource !== null && $quoteSource !== '') {
+                $extensionAttributes->setTnwQuoteSource((string) $quoteSource);
+            }
+        }
+
         $cart->setExtensionAttributes($extensionAttributes);
     }
 }

--- a/Plugin/Cart/AddCartAttributesPlugin.php
+++ b/Plugin/Cart/AddCartAttributesPlugin.php
@@ -101,6 +101,11 @@ class AddCartAttributesPlugin
             if ($quoteSource !== null && $quoteSource !== '') {
                 $extensionAttributes->setTnwQuoteSource((string) $quoteSource);
             }
+
+            $childQuoteId = $cart->getData('tnw_child_quote_id');
+            if ($childQuoteId !== null && $childQuoteId !== '') {
+                $extensionAttributes->setTnwChildQuoteId((int) $childQuoteId);
+            }
         }
 
         $cart->setExtensionAttributes($extensionAttributes);

--- a/Plugin/Cart/AddCartItemAttributesPlugin.php
+++ b/Plugin/Cart/AddCartItemAttributesPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TNW\Idealdata\Plugin\Cart;
 
+use Magento\Framework\App\State;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Api\Data\CartItemExtensionFactory;
@@ -16,7 +17,8 @@ class AddCartItemAttributesPlugin
     public function __construct(
         private readonly CartItemExtensionFactory $itemExtensionFactory,
         private readonly QuoteItemCollectionFactory $itemCollectionFactory,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly State $appState
     ) {
     }
 
@@ -76,22 +78,10 @@ class AddCartItemAttributesPlugin
         $quoteIdsToLoad = [];
         foreach ($carts as $cart) {
             $items = $cart->getItems();
-            $this->logger->info(sprintf(
-                'TNW_Idealdata DEBUG ensureItemsLoaded: cart_id=%d items_count=%d getItems_empty=%s getItems_type=%s',
-                (int) $cart->getId(),
-                (int) $cart->getItemsCount(),
-                empty($items) ? 'true' : 'false',
-                is_array($items) ? 'array(' . count($items) . ')' : gettype($items)
-            ));
             if (empty($items) && (int) $cart->getItemsCount() > 0) {
                 $quoteIdsToLoad[] = (int) $cart->getId();
             }
         }
-
-        $this->logger->info(sprintf(
-            'TNW_Idealdata DEBUG ensureItemsLoaded: quoteIdsToLoad=[%s]',
-            implode(',', $quoteIdsToLoad)
-        ));
 
         if (empty($quoteIdsToLoad)) {
             return;
@@ -99,23 +89,30 @@ class AddCartItemAttributesPlugin
 
         $itemsMap = $this->batchLoadQuoteItems($quoteIdsToLoad);
 
+        // Only apply the setData('items', ...) fix in REST/SOAP API context.
+        // In admin/frontend flows Magento relies on the internal $_items
+        // property (populated via setItems) — overwriting data['items'] there
+        // breaks operations like "Create Order → Move from cart" where Magento
+        // loses product_id references when it resolves items from data array.
+        $isApiContext = false;
+        try {
+            $areaCode = $this->appState->getAreaCode();
+            $isApiContext = in_array($areaCode, ['webapi_rest', 'webapi_soap'], true);
+        } catch (\Throwable $e) {
+            // Area code not set — treat as non-API context (safer default)
+        }
+
         foreach ($carts as $cart) {
             $cartId = (int) $cart->getId();
             if (isset($itemsMap[$cartId])) {
                 $items = $itemsMap[$cartId];
                 $cart->setItems($items);
-
-                // Also set via setData to ensure it persists for REST serialization
-                $cart->setData('items', $items);
-
-                // Verify it persisted by re-reading getItems()
-                $verifyItems = $cart->getItems();
-                $this->logger->info(sprintf(
-                    'TNW_Idealdata DEBUG setItems: cart_id=%d set_count=%d after_getItems_count=%s',
-                    $cartId,
-                    count($items),
-                    is_array($verifyItems) ? count($verifyItems) : 'not-array:' . gettype($verifyItems)
-                ));
+                // The REST serializer reads items via getData('items'), not the
+                // internal $_items property. Apply this fix only for API
+                // contexts so inactive carts have items in the REST response.
+                if ($isApiContext) {
+                    $cart->setData('items', $items);
+                }
             }
         }
     }

--- a/Plugin/Cart/AddCartItemAttributesPlugin.php
+++ b/Plugin/Cart/AddCartItemAttributesPlugin.php
@@ -29,6 +29,14 @@ class AddCartItemAttributesPlugin
         CartRepositoryInterface $subject,
         CartInterface $result
     ): CartInterface {
+        // Only operate in REST/SOAP API contexts. In admin/frontend flows
+        // Magento relies on its native quote-item loading and any interference
+        // (batch-loading items, setItems, setData) can break operations like
+        // "Create Order → Move from cart" where product_id references are lost.
+        if (!$this->isApiContext()) {
+            return $result;
+        }
+
         try {
             $this->ensureItemsLoaded([$result]);
             $this->attachItemAttributes($result);
@@ -49,6 +57,10 @@ class AddCartItemAttributesPlugin
         CartRepositoryInterface $subject,
         CartSearchResultsInterface $result
     ): CartSearchResultsInterface {
+        if (!$this->isApiContext()) {
+            return $result;
+        }
+
         try {
             $carts = $result->getItems();
             if (!empty($carts)) {
@@ -65,6 +77,17 @@ class AddCartItemAttributesPlugin
         }
 
         return $result;
+    }
+
+    private function isApiContext(): bool
+    {
+        try {
+            $areaCode = $this->appState->getAreaCode();
+            return in_array($areaCode, ['webapi_rest', 'webapi_soap'], true);
+        } catch (\Throwable $e) {
+            // Area code not set — treat as non-API context (safer default)
+            return false;
+        }
     }
 
     /**
@@ -89,30 +112,15 @@ class AddCartItemAttributesPlugin
 
         $itemsMap = $this->batchLoadQuoteItems($quoteIdsToLoad);
 
-        // Only apply the setData('items', ...) fix in REST/SOAP API context.
-        // In admin/frontend flows Magento relies on the internal $_items
-        // property (populated via setItems) — overwriting data['items'] there
-        // breaks operations like "Create Order → Move from cart" where Magento
-        // loses product_id references when it resolves items from data array.
-        $isApiContext = false;
-        try {
-            $areaCode = $this->appState->getAreaCode();
-            $isApiContext = in_array($areaCode, ['webapi_rest', 'webapi_soap'], true);
-        } catch (\Throwable $e) {
-            // Area code not set — treat as non-API context (safer default)
-        }
-
         foreach ($carts as $cart) {
             $cartId = (int) $cart->getId();
             if (isset($itemsMap[$cartId])) {
                 $items = $itemsMap[$cartId];
                 $cart->setItems($items);
                 // The REST serializer reads items via getData('items'), not the
-                // internal $_items property. Apply this fix only for API
-                // contexts so inactive carts have items in the REST response.
-                if ($isApiContext) {
-                    $cart->setData('items', $items);
-                }
+                // internal $_items property. Set the data key explicitly so
+                // inactive carts' items appear in the REST response.
+                $cart->setData('items', $items);
             }
         }
     }

--- a/Plugin/Cart/AddCartItemAttributesPlugin.php
+++ b/Plugin/Cart/AddCartItemAttributesPlugin.php
@@ -76,10 +76,22 @@ class AddCartItemAttributesPlugin
         $quoteIdsToLoad = [];
         foreach ($carts as $cart) {
             $items = $cart->getItems();
+            $this->logger->info(sprintf(
+                'TNW_Idealdata DEBUG ensureItemsLoaded: cart_id=%d items_count=%d getItems_empty=%s getItems_type=%s',
+                (int) $cart->getId(),
+                (int) $cart->getItemsCount(),
+                empty($items) ? 'true' : 'false',
+                is_array($items) ? 'array(' . count($items) . ')' : gettype($items)
+            ));
             if (empty($items) && (int) $cart->getItemsCount() > 0) {
                 $quoteIdsToLoad[] = (int) $cart->getId();
             }
         }
+
+        $this->logger->info(sprintf(
+            'TNW_Idealdata DEBUG ensureItemsLoaded: quoteIdsToLoad=[%s]',
+            implode(',', $quoteIdsToLoad)
+        ));
 
         if (empty($quoteIdsToLoad)) {
             return;
@@ -90,7 +102,20 @@ class AddCartItemAttributesPlugin
         foreach ($carts as $cart) {
             $cartId = (int) $cart->getId();
             if (isset($itemsMap[$cartId])) {
-                $cart->setItems($itemsMap[$cartId]);
+                $items = $itemsMap[$cartId];
+                $cart->setItems($items);
+
+                // Also set via setData to ensure it persists for REST serialization
+                $cart->setData('items', $items);
+
+                // Verify it persisted by re-reading getItems()
+                $verifyItems = $cart->getItems();
+                $this->logger->info(sprintf(
+                    'TNW_Idealdata DEBUG setItems: cart_id=%d set_count=%d after_getItems_count=%s',
+                    $cartId,
+                    count($items),
+                    is_array($verifyItems) ? count($verifyItems) : 'not-array:' . gettype($verifyItems)
+                ));
             }
         }
     }

--- a/Plugin/Cart/AddCartItemAttributesPlugin.php
+++ b/Plugin/Cart/AddCartItemAttributesPlugin.php
@@ -167,24 +167,24 @@ class AddCartItemAttributesPlugin
                 }
 
                 if (method_exists($item, 'getProductId')) {
-                    $extensionAttributes->setProductId((int) $item->getProductId());
+                    $extensionAttributes->setTnwProductId((int) $item->getProductId());
                 }
 
-                $extensionAttributes->setParentItemId(
+                $extensionAttributes->setTnwParentItemId(
                     $item->getParentItemId() ? (int) $item->getParentItemId() : null
                 );
-                $extensionAttributes->setProductType($item->getProductType() ?? '');
+                $extensionAttributes->setTnwProductType($item->getProductType() ?? '');
 
                 if (method_exists($item, 'getRowTotal')) {
-                    $extensionAttributes->setRowTotal((float) $item->getRowTotal());
+                    $extensionAttributes->setTnwRowTotal((float) $item->getRowTotal());
                 }
 
                 if (method_exists($item, 'getRowTotalWithDiscount')) {
-                    $extensionAttributes->setRowTotalWithDiscount(
+                    $extensionAttributes->setTnwRowTotalWithDiscount(
                         (float) $item->getRowTotalWithDiscount()
                     );
                 } elseif (method_exists($item, 'getData')) {
-                    $extensionAttributes->setRowTotalWithDiscount(
+                    $extensionAttributes->setTnwRowTotalWithDiscount(
                         (float) $item->getData('row_total_with_discount')
                     );
                 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tnw/module-idealdata",
   "description": "Idealdata module for Magento 2",
   "type": "magento2-module",
-  "version": "1.2",
+  "version": "1.3",
   "license": "OSL-3.0",
   "require": {
     "magento/framework": ">=103.0.6",

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -96,4 +96,19 @@
             <column name="tnw_updated_at"/>
         </index>
     </table>
+
+    <!-- Cart parent tracking: added to quote to record origin of a cart.
+         Used by IdealData to differentiate Cart A (persistent customer cart)
+         from Cart B (transient admin-split cart that becomes an order). -->
+    <table name="quote" resource="checkout">
+        <column xsi:type="int" name="tnw_parent_quote_id" unsigned="true" nullable="true"
+                comment="TNW IdealData: parent quote ID (Cart A) when this quote was created by admin 'move items from cart' flow"/>
+        <column xsi:type="timestamp" name="tnw_parent_quote_created_at" nullable="true"
+                comment="TNW IdealData: parent quote created_at snapshot (for journey time-to-convert calculation)"/>
+        <column xsi:type="varchar" name="tnw_quote_source" nullable="true" length="32"
+                comment="TNW IdealData: quote origin (admin_split_from_cart | customer_frontend | reorder | api | admin_manual)"/>
+        <index referenceId="TNW_QUOTE_PARENT_ID" indexType="btree">
+            <column name="tnw_parent_quote_id"/>
+        </index>
+    </table>
 </schema>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -107,6 +107,8 @@
                 comment="TNW IdealData: parent quote created_at snapshot (for journey time-to-convert calculation)"/>
         <column xsi:type="varchar" name="tnw_quote_source" nullable="true" length="32"
                 comment="TNW IdealData: quote origin (admin_split_from_cart | customer_frontend | reorder | api | admin_manual)"/>
+        <column xsi:type="int" name="tnw_child_quote_id" unsigned="true" nullable="true"
+                comment="TNW IdealData: most recent child quote ID (Cart B) created from this quote via admin move-items"/>
         <index referenceId="TNW_QUOTE_PARENT_ID" indexType="btree">
             <column name="tnw_parent_quote_id"/>
         </index>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -52,5 +52,15 @@
         "index": {
             "TNW_CAE_UPDATED_AT": true
         }
+    },
+    "quote": {
+        "column": {
+            "tnw_parent_quote_id": true,
+            "tnw_parent_quote_created_at": true,
+            "tnw_quote_source": true
+        },
+        "index": {
+            "TNW_QUOTE_PARENT_ID": true
+        }
     }
 }

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -57,7 +57,8 @@
         "column": {
             "tnw_parent_quote_id": true,
             "tnw_parent_quote_created_at": true,
-            "tnw_quote_source": true
+            "tnw_quote_source": true,
+            "tnw_child_quote_id": true
         },
         "index": {
             "TNW_QUOTE_PARENT_ID": true

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,6 +18,11 @@
         <plugin name="tnw_idealdata_cart_item_attributes" type="TNW\Idealdata\Plugin\Cart\AddCartItemAttributesPlugin" sortOrder="20"/>
     </type>
 
+    <!-- Admin order creation: record source cart (Cart A → Cart B lineage) -->
+    <type name="Magento\Sales\Model\AdminOrder\Create">
+        <plugin name="tnw_idealdata_record_source_cart" type="TNW\Idealdata\Plugin\AdminOrder\RecordSourceCartPlugin" sortOrder="10"/>
+    </type>
+
     <!-- Preferences -->
     <preference for="TNW\Idealdata\Api\OrderStatusRepositoryInterface" type="TNW\Idealdata\Model\OrderStatusRepository"/>
 

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -5,4 +5,8 @@
         <observer name="tnw_idealdata_capture_failed_payment"
                   instance="TNW\Idealdata\Observer\CaptureFailedPaymentObserver"/>
     </event>
+    <event name="sales_model_service_quote_submit_before">
+        <observer name="tnw_idealdata_set_quote_source"
+                  instance="TNW\Idealdata\Observer\SetQuoteSourceObserver"/>
+    </event>
 </config>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -26,6 +26,7 @@
         <attribute code="tnw_parent_quote_id" type="int"/>
         <attribute code="tnw_parent_quote_created_at" type="string"/>
         <attribute code="tnw_quote_source" type="string"/>
+        <attribute code="tnw_child_quote_id" type="int"/>
     </extension_attributes>
 
     <!-- Extra fields on Cart Item -->

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -29,12 +29,13 @@
         <attribute code="tnw_child_quote_id" type="int"/>
     </extension_attributes>
 
-    <!-- Extra fields on Cart Item -->
+    <!-- Extra fields on Cart Item (tnw_ prefixed to avoid collision with
+         Magento's magic getters on Quote\Item — see getAttributeValueFromExtensibleObject) -->
     <extension_attributes for="Magento\Quote\Api\Data\CartItemInterface">
-        <attribute code="product_id" type="int"/>
-        <attribute code="parent_item_id" type="int"/>
-        <attribute code="product_type" type="string"/>
-        <attribute code="row_total" type="float"/>
-        <attribute code="row_total_with_discount" type="float"/>
+        <attribute code="tnw_product_id" type="int"/>
+        <attribute code="tnw_parent_item_id" type="int"/>
+        <attribute code="tnw_product_type" type="string"/>
+        <attribute code="tnw_row_total" type="float"/>
+        <attribute code="tnw_row_total_with_discount" type="float"/>
     </extension_attributes>
 </config>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -22,6 +22,10 @@
         <attribute code="coupon_code" type="string"/>
         <attribute code="applied_rule_ids" type="string"/>
         <attribute code="customer_is_guest" type="int"/>
+        <!-- Cart parent tracking: set on the quote created by admin "move items from cart" flow -->
+        <attribute code="tnw_parent_quote_id" type="int"/>
+        <attribute code="tnw_parent_quote_created_at" type="string"/>
+        <attribute code="tnw_quote_source" type="string"/>
     </extension_attributes>
 
     <!-- Extra fields on Cart Item -->

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="TNW_Idealdata" setup_version="1.0.0">
+    <module name="TNW_Idealdata" setup_version="1.3.0">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_CatalogInventory"/>


### PR DESCRIPTION
## Summary
This PR adds comprehensive tracking of cart origin and parent-child quote relationships to support IdealData's journey analytics. It distinguishes between different order creation paths (customer frontend, API, reorder, admin manual, and admin split-from-cart) and records lineage when admins move items from a customer's persistent cart to create a new order.

## Key Changes

- **New Plugin: RecordSourceCartPlugin** — Intercepts admin order creation to detect whether items were moved from the customer's active cart by comparing item counts before/after. Records the source as `admin_split_from_cart` with parent/child quote links, `reorder`, or `admin_manual`.

- **New Observer: SetQuoteSourceObserver** — Sets `tnw_quote_source` on quotes at submission time for non-admin contexts (customer frontend, API, reorder). Skips admin orders since they're handled by the plugin.

- **Database Schema Extensions** — Added four new columns to the `quote` table:
  - `tnw_parent_quote_id`: References the customer's persistent cart (Cart A) when this quote was created via admin move-items
  - `tnw_parent_quote_created_at`: Snapshot of parent cart creation time for journey time-to-convert calculation
  - `tnw_quote_source`: Origin classification (admin_split_from_cart | customer_frontend | reorder | api | admin_manual)
  - `tnw_child_quote_id`: Most recent child quote created from this quote via admin move-items

- **Extension Attributes** — Exposed new cart and cart item attributes via REST/SOAP APIs:
  - Cart: `tnw_parent_quote_id`, `tnw_parent_quote_created_at`, `tnw_quote_source`, `tnw_child_quote_id`
  - Cart Item: Prefixed existing attributes with `tnw_` to avoid collision with Magento's magic getters

- **AddCartItemAttributesPlugin Refinement** — Restricted to API contexts only (webapi_rest, webapi_soap) to prevent interference with admin/frontend quote operations. Added explicit `setData('items')` call to ensure inactive carts' items appear in REST responses.

- **AddCartAttributesPlugin Enhancement** — Attached new parent/child tracking attributes to cart extension attributes.

## Implementation Details

- All quote updates use raw SQL to avoid side effects (collectTotals, observers, etc.) and include `updated_at` bumps to force re-sync
- Timestamps are set +1 second in the future to guarantee they're after `createOrder()` completion
- Comprehensive error handling with logging to prevent tracking failures from breaking order creation
- Safe area code detection with fallback to non-API context as default

https://claude.ai/code/session_01MhSzZtPUKkSvgJZ9mKGr6D